### PR TITLE
Added missing fallbacks for Facebook and Twitter

### DIFF
--- a/snippets/meta_information.php
+++ b/snippets/meta_information.php
@@ -65,7 +65,7 @@
 
 <?php // Open Graph ?>
 
-<meta property="og:title" content="<?= $page->og_title()->or($page->meta_title())->or($page->title()) ?>">
+<meta property="og:title" content="<?= $page->og_title()->or($page->meta_title())->or($site->og_title())->or($site->meta_title())->or($page->title()) ?>">
 
 <meta property="og:description" content="<?= $page->og_description()->or($page->meta_description())->or($site->meta_description()) ?>">
 
@@ -114,7 +114,7 @@
 
 <meta name="twitter:card" content="<?= $page->twitter_card_type()->or($site->twitter_card_type())->value() ?>">
 
-<meta name="twitter:title" content="<?= $page->twitter_title()->or($page->meta_title())->or($page->title()) ?>">
+<meta name="twitter:title" content="<?= $page->twitter_title()->or($page->meta_title())->or($site->twitter_title())->or($site->meta_title())->or($page->title()) ?>">
 
 <meta name="twitter:description" content="<?= $page->twitter_description()->or($page->meta_description())->or($site->meta_description()) ?>">
 


### PR DESCRIPTION
When setting up the titles for Facebook and Twitter (site blueprint), I noticed that they did not show up on the homepages meta information. This should fix it.