### PR TITLE
Fixing default Schema Image URL

### DIFF
--- a/snippets/meta_information.php
+++ b/snippets/meta_information.php
@@ -53,7 +53,7 @@
 
 <?php // Image ?>
 
-<meta id="schema_image" itemprop="image" content="<?= $page->meta_image()->or($site->meta_image()) ?>">
+<meta id="schema_image" itemprop="image" content="<?= $page->meta_image()->or($site->meta_image())->toFile()->url() ?>">
 
 <?php // Author ?>
 


### PR DESCRIPTION
Default Schema Image was returning Kirby's Image object and not the URL.