### PR TITLE
Keep rel="alternate" conditional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "diesdasdigital/kirby-meta-knight",
   "description": "Meta Knight – SEO for Kirby",
   "type": "kirby-plugin",
+  "version": "1.2.1",
   "license": "BSD-3-Clause",
   "authors": [
     {

--- a/snippets/meta_information.php
+++ b/snippets/meta_information.php
@@ -55,10 +55,12 @@
 
 <?php // Alternate languages ?>
 
-<?php foreach ($kirby->languages() as $language): ?>
-  <link rel="alternate" hreflang="<?= strtolower(html($language->code())) ?>" href="<?= $page->url($language->code()) ?>">
-<?php endforeach; ?>
-<link rel="alternate" hreflang="x-default" href="<?= $page->url($kirby->defaultLanguage()->code()) ?>">
+<?php if ($defaultLanguage = $kirby->defaultLanguage()): ?>
+  <?php foreach ($kirby->languages() as $language): ?>
+    <link rel="alternate" hreflang="<?= strtolower(html($language->code())) ?>" href="<?= $page->url($language->code()) ?>">
+  <?php endforeach; ?>
+  <link rel="alternate" hreflang="x-default" href="<?= $page->url($defaultLanguage->code()) ?>">
+<?php endif; ?>
 
 <?php // Image ?>
 


### PR DESCRIPTION
Since kirby->defaultLanguage() returns null by default, the page will crash without definition. This change keeps the whole rel="alternate" stuff conditional.