### PR TITLE
Fixed: No longer crashes on single-lang pages

### DIFF
--- a/snippets/meta_information.php
+++ b/snippets/meta_information.php
@@ -55,10 +55,12 @@
 
 <?php // Alternate languages ?>
 
-<?php foreach ($kirby->languages() as $language): ?>
-  <link rel="alternate" hreflang="<?= strtolower(html($language->code())) ?>" href="<?= $page->url($language->code()) ?>">
-<?php endforeach; ?>
-<link rel="alternate" hreflang="x-default" href="<?= $page->url($kirby->defaultLanguage()->code()) ?>">
+<?php if ($kirby->languages()->count() > 0): ?>
+  <?php foreach ($kirby->languages() as $language): ?>
+    <link rel="alternate" hreflang="<?= strtolower(html($language->code())) ?>" href="<?= $page->url($language->code()) ?>">
+  <?php endforeach; ?>
+  <link rel="alternate" hreflang="x-default" href="<?= $page->url($kirby->defaultLanguage()->code()) ?>">
+<?php endif ?>
 
 <?php // Image ?>
 


### PR DESCRIPTION
This pull-request fixes issue #48 in the simplest way I could think of. We're simply checking whether the language object of the instance has any content to it. If no, we don't run the code for generating a meta list of alternate language versions of the page.