### PR TITLE
Render `schema_image` for itemscope in meta snippet conditionally

### DIFF
--- a/snippets/meta_information.php
+++ b/snippets/meta_information.php
@@ -28,7 +28,7 @@
 
 <?php // Schema ?>
 
-<style itemscope itemtype="https://schema.org/WebSite" itemref="schema_name schema_description schema_image"></style>
+<style itemscope itemtype="https://schema.org/WebSite" itemref="schema_name schema_description <?= ($page->meta_image()->toFile() ?? $site->meta_image()->toFile()) ? 'schema_image' : null ?>"></style>
 
 <?php // Page Title ?>
 


### PR DESCRIPTION
Fixes Google Search Console "Reference to non-existent item" error when trying to index a website that does not have a meta image set

fixes #53